### PR TITLE
[IOS-9382] Remove ClipboardContent from Bonus Data

### DIFF
--- a/System Services/SystemServices.m
+++ b/System Services/SystemServices.m
@@ -416,7 +416,6 @@
     NSString *timeZone = [self timeZoneSS];
     NSString *currency = [self currency];
     NSString *applicationVersion = [self applicationVersion];
-    NSString *clipboardContent = [self clipboardContent];
     NSString *cFUUID = [self cfuuid];
     NSString *cPUUsage = [NSString stringWithFormat:@"%f", [self applicationCPUUsage]];
     
@@ -709,10 +708,6 @@
         // Invalid value
         applicationVersion = @"Unknown";
     }
-    if (clipboardContent == nil || clipboardContent.length <= 0) {
-        // Invalid value
-        clipboardContent = @"Unknown";
-    }
     if (cFUUID == nil || cFUUID.length <= 0) {
         // Invalid value
         cFUUID = @"Unknown";
@@ -796,7 +791,6 @@
                                                                  timeZone,
                                                                  currency,
                                                                  applicationVersion,
-                                                                 clipboardContent,
                                                                  cFUUID,
                                                                  cPUUsage,
                                                                  nil]
@@ -873,7 +867,6 @@
                                                                  @"TimeZone",
                                                                  @"Currency",
                                                                  @"ApplicationVersion",
-                                                                 @"ClipboardContent",
                                                                  @"CFUUID",
                                                                  @"CPUUsage",
                                                                  nil]];

--- a/SystemServicesDemo/SystemServicesDemo.xcodeproj/project.pbxproj
+++ b/SystemServicesDemo/SystemServicesDemo.xcodeproj/project.pbxproj
@@ -364,7 +364,7 @@
 				ORGANIZATIONNAME = "Shmoopi LLC";
 				TargetAttributes = {
 					01ADF9F216051BFE008B0A6B = {
-						DevelopmentTeam = Q2636DAEP4;
+						DevelopmentTeam = 46H57CBD4Q;
 					};
 				};
 			};
@@ -373,6 +373,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 01ADF9E816051BFE008B0A6B;
@@ -556,7 +557,7 @@
 		01ADFA1216051BFE008B0A6B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DEVELOPMENT_TEAM = Q2636DAEP4;
+				DEVELOPMENT_TEAM = 46H57CBD4Q;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SystemServicesDemo/SystemServicesDemo-Prefix.pch";
 				INFOPLIST_FILE = "SystemServicesDemo/SystemServicesDemo-Info.plist";
@@ -574,7 +575,7 @@
 		01ADFA1316051BFE008B0A6B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DEVELOPMENT_TEAM = Q2636DAEP4;
+				DEVELOPMENT_TEAM = 46H57CBD4Q;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SystemServicesDemo/SystemServicesDemo-Prefix.pch";
 				INFOPLIST_FILE = "SystemServicesDemo/SystemServicesDemo-Info.plist";

--- a/SystemServicesDemo/SystemServicesDemo/SystemServicesDemoViewController.m
+++ b/SystemServicesDemo/SystemServicesDemo/SystemServicesDemoViewController.m
@@ -86,7 +86,11 @@
     NSString *ApplicationVersion = [NSString stringWithFormat:@"Application Version: %@", [SystemSharedServices applicationVersion]];
     NSString *ClipboardContent = [NSString stringWithFormat:@"ClipBoard Content: \"%@\"", [SystemSharedServices clipboardContent]];
     NSString *CFUUID = [NSString stringWithFormat:@"CFUUID: %@", [SystemSharedServices cfuuid]];
-    
+
+    NSDictionary *allSystemInformation = [[SystemServices sharedServices] allSystemInformation];
+    NSAssert(![[allSystemInformation allKeys] containsObject:@"ClipboardContent"], @"We should not be including clipboard content in allSystemInformation");
+    NSAssert([[allSystemInformation allKeys] containsObject:@"ApplicationVersion"], @"We should be including application version in allSystemInformation");
+
     // Make an array of all the hardware information
     NSArray *arrayofHW = [[NSArray alloc] initWithObjects:SystemUptime, DeviceModel, DeviceName, SystemName, SystemVersion, SystemDeviceTypeFormattedNO, SystemDeviceTypeFormattedYES, ScreenWidth, ScreenHeight, ScreenBrightness, MultitaskingEnabled, ProximitySensorEnabled, DebuggerAttached, PluggedIn, stepCountingAvailable, distanceAvailable, floorCountingAvailable, Jailbroken, NumberProcessors, NumberActiveProcessors, ProcessorsUsage, AccessoriesAttached, HeadphonesAttached, NumberAttachedAccessories, NameAttachedAccessories, BatteryLevel, Charging, FullyCharged, DeviceOrientation, Country, Language, TimeZone, Currency, ApplicationVersion, ClipboardContent, CFUUID, nil];
     


### PR DESCRIPTION
In iOS 14, it's considered a violation of user privacy to access the clipboard content. We were including it in the bonus data that we send to various service calls (for sketchy evaluation). The clipboard content was just bundled into the "all system info" dictionary that we use for bonus data. This PR just alters the System Services code that generates that dictionary so that it does not include clipboard content.

Removed clipboard content from the -allSystemInformation method (it’s no longer bundled into the overall dictionary of system info). The SystemServices code still allows you to specifically ask for clipboard content, but the way TN app uses this code, it won’t access clipboard content when it calls -allSystemInformation.

Added a little more code and a couple asserts to the demo app to confirm that we aren’t including clipboard content in the overall dictionary.